### PR TITLE
fix: reject insecure discovered jwks_uri values

### DIFF
--- a/packages/did-jwks/src/did-jwks.test.ts
+++ b/packages/did-jwks/src/did-jwks.test.ts
@@ -132,6 +132,36 @@ describe("fetchJwksDidDocument()", () => {
     expectJwksDidDocument(did, doc)
   })
 
+  it("does not fetch http jwks_uri values from OIDC discovery unless the host is allowed", async () => {
+    const mockFetch = vi.fn((url: string) => {
+      if (url === "https://example.com/.well-known/openid-configuration") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              jwks_uri: "http://example.com/keys"
+            })
+        })
+      }
+
+      return Promise.resolve({ ok: false, status: 404 })
+    }) as unknown as typeof globalThis.fetch
+
+    const did = "did:jwks:example.com"
+    const doc = await fetchJwksDidDocument(did, {
+      fetch: mockFetch
+    })
+
+    expect(doc).toBeNull()
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/.well-known/jwks.json"
+    )
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/.well-known/openid-configuration"
+    )
+    expect(mockFetch).not.toHaveBeenCalledWith("http://example.com/keys")
+  })
+
   it("resolves did:jwks:accounts.google.com", async () => {
     const mockFetch = createMockOidcHost({
       jwks: accountsGoogleJwks,

--- a/packages/did-jwks/src/did-jwks.test.ts
+++ b/packages/did-jwks/src/did-jwks.test.ts
@@ -47,6 +47,33 @@ describe("fetchJwksDidDocument()", () => {
     expectJwksDidDocument(did, doc)
   })
 
+  it("handles IPv6 localhost with ports", async () => {
+    const mockFetch = mockFetchFn({
+      keys: [
+        {
+          kty: "RSA",
+          use: "sig",
+          kid: "test-key-1",
+          alg: "RS256",
+          n: "test-n-value",
+          e: "AQAB"
+        }
+      ]
+    })
+
+    const did = "did:jwks:%5B%3A%3A1%5D%3A3000"
+    const doc = await fetchJwksDidDocument(did, {
+      fetch: mockFetch,
+      allowedHttpHosts: ["[::1]"]
+    })
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://[::1]:3000/.well-known/jwks.json"
+    )
+    expectJwksDidDocument(did, doc)
+  })
+
   it("handles subdirectories with direct path resolution", async () => {
     const mockFetch = mockFetchFn({
       keys: [
@@ -160,6 +187,32 @@ describe("fetchJwksDidDocument()", () => {
       "https://example.com/.well-known/openid-configuration"
     )
     expect(mockFetch).not.toHaveBeenCalledWith("http://example.com/keys")
+  })
+
+  it("does not fetch an allowed http jwks_uri for a different DID host", async () => {
+    const mockFetch = vi.fn((url: string) => {
+      if (url === "https://example.com/.well-known/openid-configuration") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              jwks_uri: "http://localhost/keys"
+            })
+        })
+      }
+
+      return Promise.resolve({ ok: false, status: 404 })
+    }) as unknown as typeof globalThis.fetch
+
+    const did = "did:jwks:example.com"
+    const doc = await fetchJwksDidDocument(did, {
+      fetch: mockFetch,
+      allowedHttpHosts: ["localhost"]
+    })
+
+    expect(doc).toBeNull()
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(mockFetch).not.toHaveBeenCalledWith("http://localhost/keys")
   })
 
   it("resolves did:jwks:accounts.google.com", async () => {

--- a/packages/did-jwks/src/fetch.ts
+++ b/packages/did-jwks/src/fetch.ts
@@ -70,6 +70,10 @@ export async function fetchJwks(
     opts.fetch
   )
   if (openidConfig?.jwks_uri) {
+    if (!isAllowedFetchUrl(openidConfig.jwks_uri, opts.allowedHttpHosts)) {
+      return null
+    }
+
     return await fetchWithSchema(
       openidConfig.jwks_uri,
       JsonWebKeySetSchema,
@@ -137,4 +141,21 @@ function getProtocol(
   }
 
   return "https"
+}
+
+function isAllowedFetchUrl(
+  url: string,
+  allowedHttpHosts: string[] = []
+): boolean {
+  const parsed = new URL(url)
+  if (parsed.protocol === "https:") {
+    return true
+  }
+
+  if (parsed.protocol !== "http:") {
+    return false
+  }
+
+  const hostWithoutPort = parsed.hostname.split(":")[0] ?? parsed.hostname
+  return allowedHttpHosts.includes(hostWithoutPort)
 }

--- a/packages/did-jwks/src/fetch.ts
+++ b/packages/did-jwks/src/fetch.ts
@@ -43,8 +43,9 @@ export interface FetchJwksOptions {
    */
   fetch?: typeof globalThis.fetch
   /**
-   * The hosts that are allowed to be used via `http`. All other hosts will
-   * require `https`.  This is useful for local development and testing.
+   * The hosts that are allowed to be used via `http`. All other hosts require
+   * `https`. Discovered HTTP JWKS URLs must also match the DID's hostname. This
+   * is useful for local development and testing.
    *
    * @default []
    */
@@ -56,6 +57,7 @@ export async function fetchJwks(
   opts: FetchJwksOptions = {}
 ): Promise<JsonWebKeySet | null> {
   const base = buildBaseUrl(did, opts.allowedHttpHosts)
+  const baseHostname = new URL(base).hostname
   const urls = buildResolutionUrls(base)
 
   const jwks = await fetchWithSchema(urls.jwks, JsonWebKeySetSchema, opts.fetch)
@@ -70,7 +72,13 @@ export async function fetchJwks(
     opts.fetch
   )
   if (openidConfig?.jwks_uri) {
-    if (!isAllowedFetchUrl(openidConfig.jwks_uri, opts.allowedHttpHosts)) {
+    if (
+      !isAllowedFetchUrl(
+        openidConfig.jwks_uri,
+        baseHostname,
+        opts.allowedHttpHosts
+      )
+    ) {
       return null
     }
 
@@ -133,18 +141,13 @@ function getProtocol(
   path: string,
   allowedHttpHosts: string[] = []
 ): "http" | "https" {
-  const [host] = path.split("/")
-
-  if (host) {
-    const hostWithoutPort = host.split(":")[0] ?? host
-    return allowedHttpHosts.includes(hostWithoutPort) ? "http" : "https"
-  }
-
-  return "https"
+  const hostname = new URL(`https://${path}`).hostname
+  return isAllowedHttpHost(hostname, allowedHttpHosts) ? "http" : "https"
 }
 
 function isAllowedFetchUrl(
   url: string,
+  didHostname: string,
   allowedHttpHosts: string[] = []
 ): boolean {
   const parsed = new URL(url)
@@ -156,6 +159,15 @@ function isAllowedFetchUrl(
     return false
   }
 
-  const hostWithoutPort = parsed.hostname.split(":")[0] ?? parsed.hostname
-  return allowedHttpHosts.includes(hostWithoutPort)
+  return (
+    parsed.hostname === didHostname &&
+    isAllowedHttpHost(parsed.hostname, allowedHttpHosts)
+  )
+}
+
+function isAllowedHttpHost(
+  hostname: string,
+  allowedHttpHosts: string[] = []
+): boolean {
+  return allowedHttpHosts.includes(hostname)
 }


### PR DESCRIPTION
## Summary

Rejects insecure `http:` JWKS URLs returned from OIDC discovery unless the discovered host is explicitly listed in `allowedHttpHosts`.

This keeps fallback discovery aligned with the existing direct DID resolution policy: HTTPS by default, with opt-in HTTP only for trusted local/dev hosts.

## Verification

- `pnpm --filter did-jwks test`
- `pnpm run build && pnpm run check`

Note: the initial `pnpm run check` after a fresh install failed because `jwks-did-resolver` expects the local `did-jwks` dist types to exist. Running `pnpm run build` first generated the workspace package dist, then the full check passed.
