### PR TITLE
fix: ignore malformed jwks json responses

### DIFF
--- a/packages/did-jwks/src/did-jwks.test.ts
+++ b/packages/did-jwks/src/did-jwks.test.ts
@@ -287,4 +287,20 @@ describe("fetchJwksDidDocument()", () => {
       "https://example.com/.well-known/openid-configuration"
     )
   })
+
+  it("rethrows non-syntax JSON read failures", async () => {
+    const error = new Error("body stream aborted")
+    const mockFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.reject(error)
+      })
+    ) as unknown as typeof globalThis.fetch
+
+    const did = "did:jwks:example.com"
+
+    await expect(
+      fetchJwksDidDocument(did, { fetch: mockFetch })
+    ).rejects.toThrow("body stream aborted")
+  })
 })

--- a/packages/did-jwks/src/did-jwks.test.ts
+++ b/packages/did-jwks/src/did-jwks.test.ts
@@ -267,4 +267,24 @@ describe("fetchJwksDidDocument()", () => {
 
     expect(doc).toBeNull()
   })
+
+  it("returns null when JWKS and discovery responses are invalid JSON", async () => {
+    const mockFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.reject(new SyntaxError("Unexpected token"))
+      })
+    ) as unknown as typeof globalThis.fetch
+
+    const did = "did:jwks:example.com"
+    const doc = await fetchJwksDidDocument(did, { fetch: mockFetch })
+
+    expect(doc).toBeNull()
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/.well-known/jwks.json"
+    )
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/.well-known/openid-configuration"
+    )
+  })
 })

--- a/packages/did-jwks/src/utils/fetch-with-schema.ts
+++ b/packages/did-jwks/src/utils/fetch-with-schema.ts
@@ -18,7 +18,14 @@ export async function fetchWithSchema<T extends v.GenericSchema>(
     return null
   }
 
-  const result = v.safeParse(schema, await resp.json())
+  let json: unknown
+  try {
+    json = await resp.json()
+  } catch {
+    return null
+  }
+
+  const result = v.safeParse(schema, json)
 
   if (result.success) {
     return result.output

--- a/packages/did-jwks/src/utils/fetch-with-schema.ts
+++ b/packages/did-jwks/src/utils/fetch-with-schema.ts
@@ -21,8 +21,11 @@ export async function fetchWithSchema<T extends v.GenericSchema>(
   let json: unknown
   try {
     json = await resp.json()
-  } catch {
-    return null
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return null
+    }
+    throw error
   }
 
   const result = v.safeParse(schema, json)


### PR DESCRIPTION
## Summary

- return `null` when a successful JWKS or OIDC discovery response has malformed JSON
- keep non-OK responses as resolution misses and keep network exceptions unchanged
- add regression coverage for invalid JSON on both direct JWKS and discovery fetches

## Why

A provider can return a `200` response with a malformed body. That should behave like an unusable JWKS/discovery document rather than throwing out of the low-level fetch/schema helper.

## Verification

- `pnpm --filter did-jwks test`
- `pnpm run build && pnpm run check`
