### PR TITLE
fix: skip symmetric jwks keys

### DIFF
--- a/.changeset/tidy-bikes-check.md
+++ b/.changeset/tidy-bikes-check.md
@@ -1,5 +1,5 @@
 ---
-"did-jwks": patch
+"did-jwks": major
 ---
 
 Skip symmetric JWKs when creating DID verification methods.

--- a/.changeset/tidy-bikes-check.md
+++ b/.changeset/tidy-bikes-check.md
@@ -1,0 +1,5 @@
+---
+"did-jwks": patch
+---
+
+Skip symmetric JWKs when creating DID verification methods.

--- a/packages/did-jwks/src/did-jwks.test.ts
+++ b/packages/did-jwks/src/did-jwks.test.ts
@@ -294,6 +294,23 @@ describe("fetchJwksDidDocument()", () => {
     expect(JSON.stringify(doc)).not.toContain("secret")
   })
 
+  it("returns null when JWKS contains no public keys", async () => {
+    const mockFetch = mockFetchFn({
+      keys: [
+        {
+          kty: "oct",
+          kid: "symmetric-secret",
+          k: "secret"
+        }
+      ]
+    })
+
+    const did = "did:jwks:example.com"
+    const doc = await fetchJwksDidDocument(did, { fetch: mockFetch })
+
+    expect(doc).toBeNull()
+  })
+
   it("returns error when no JWKS found", async () => {
     const mockFetch = mockFetchFn({})
 

--- a/packages/did-jwks/src/did-jwks.test.ts
+++ b/packages/did-jwks/src/did-jwks.test.ts
@@ -256,6 +256,44 @@ describe("fetchJwksDidDocument()", () => {
     })
   })
 
+  it("does not expose symmetric keys as verification methods", async () => {
+    const mockFetch = mockFetchFn({
+      keys: [
+        {
+          kty: "oct",
+          kid: "symmetric-secret",
+          k: "secret"
+        },
+        {
+          kty: "RSA",
+          use: "sig",
+          kid: "public-key",
+          n: "test-n-value",
+          e: "AQAB"
+        }
+      ]
+    })
+
+    const did = "did:jwks:example.com"
+    const doc = await fetchJwksDidDocument(did, { fetch: mockFetch })
+
+    expect(doc).toBeTruthy()
+    if (!doc) {
+      return
+    }
+
+    expect(doc.verificationMethod).toHaveLength(1)
+    expect(doc.verificationMethod?.[0]).toMatchObject({
+      type: "JsonWebKey",
+      publicKeyJwk: {
+        kty: "RSA",
+        kid: "public-key"
+      }
+    })
+    expect(JSON.stringify(doc)).not.toContain("symmetric-secret")
+    expect(JSON.stringify(doc)).not.toContain("secret")
+  })
+
   it("returns error when no JWKS found", async () => {
     const mockFetch = mockFetchFn({})
 

--- a/packages/did-jwks/src/did-jwks.ts
+++ b/packages/did-jwks/src/did-jwks.ts
@@ -33,13 +33,17 @@ type DidDocument = v.InferOutput<typeof MinimalDidDocumentSchema>
  *
  * @param didUri - The DID URI.
  * @param jwks - The JWKS.
- * @returns The DID document.
+ * @returns The DID document or `null` if the JWKS has no public keys.
  */
 export async function createDidJwksDidDocument(
   did: Did<"jwks">,
   jwks: JsonWebKeySet
-): Promise<DidDocument> {
+): Promise<DidDocument | null> {
   const publicKeys = jwks.keys.filter((key) => key.kty !== "oct")
+  if (publicKeys.length === 0) {
+    return null
+  }
+
   const keysWithThumbprints = await Promise.all(
     publicKeys.map(async (key) => {
       const { use } = key

--- a/packages/did-jwks/src/did-jwks.ts
+++ b/packages/did-jwks/src/did-jwks.ts
@@ -39,8 +39,9 @@ export async function createDidJwksDidDocument(
   did: Did<"jwks">,
   jwks: JsonWebKeySet
 ): Promise<DidDocument> {
+  const publicKeys = jwks.keys.filter((key) => key.kty !== "oct")
   const keysWithThumbprints = await Promise.all(
-    jwks.keys.map(async (key) => {
+    publicKeys.map(async (key) => {
       const { use } = key
       const thumbprint = await generateJwkThumbprint(key)
       return {


### PR DESCRIPTION
## Summary
- skip symmetric `oct` JWKs when generating DID verification methods
- keep mixed JWKS sets usable by preserving public keys
- add a regression test that ensures symmetric key material is not exposed in the DID document

Closes #10.

## Verification
- `pnpm --filter did-jwks test -- --run packages/did-jwks/src/did-jwks.test.ts`
- `pnpm --filter did-jwks build`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`