### PR TITLE
test: add RFC 7638 thumbprint vector

### DIFF
--- a/packages/did-jwks/src/utils/jwk-thumbprint.test.ts
+++ b/packages/did-jwks/src/utils/jwk-thumbprint.test.ts
@@ -3,6 +3,20 @@ import { describe, it, expect } from "vitest"
 import { generateJwkThumbprint } from "./jwk-thumbprint"
 
 describe("generateJwkThumbprint()", () => {
+  it("matches the RFC 7638 RSA example", async () => {
+    const jwk = {
+      kty: "RSA" as const,
+      n: "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+      e: "AQAB",
+      alg: "RS256" as const,
+      kid: "2011-04-29"
+    }
+
+    await expect(generateJwkThumbprint(jwk)).resolves.toBe(
+      "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
+    )
+  })
+
   it("generates consistent thumbprints for RSA keys", async () => {
     const jwk = {
       kty: "RSA" as const,


### PR DESCRIPTION
## Summary
- add the RFC 7638 RSA JWK thumbprint test vector to the did-jwks thumbprint tests
- keep optional JWK fields in the fixture so the test also covers ignoring non-required members

Closes #11

## Verification
- pnpm --filter=did-jwks exec vitest run src/utils/jwk-thumbprint.test.ts
- pnpm --filter=did-jwks test
- pnpm exec oxfmt --check packages/did-jwks/src/utils/jwk-thumbprint.test.ts
- git diff --check