### PR TITLE
docs: align path DID resolution examples

### DIFF
--- a/packages/did-jwks/README.md
+++ b/packages/did-jwks/README.md
@@ -43,8 +43,10 @@ console.log(didDocument)
 
 1. **Parse DID**: Extracts domain and optional path from the DID
 2. **JWKS Discovery**: Attempts to fetch JWKS from:
-   - Direct: `https://domain/.well-known/jwks.json`
-   - OAuth2 Discovery: `https://domain/.well-known/openid-configuration`
+   - Root DID direct lookup: `https://domain/.well-known/jwks.json`
+   - Path DID direct lookup: `https://domain/{path}/jwks.json`
+   - Root DID OAuth2 discovery: `https://domain/.well-known/openid-configuration`
+   - Path DID OAuth2 discovery: `https://domain/.well-known/openid-configuration/{path}`
 3. **Transform**: Converts JWKS keys to DID verification methods
 4. **Generate**: Creates a standard DID document
 
@@ -72,7 +74,7 @@ const result = await fetchJwksDidDocument(
 const result = await fetchJwksDidDocument(
   "did:jwks:auth.example.com:tenant:123"
 )
-// Resolves to https://auth.example.com/tenant/123/.well-known/jwks.json
+// Resolves to https://auth.example.com/tenant/123/jwks.json
 ```
 
 ## License (MIT)

--- a/packages/jwks-did-resolver/README.md
+++ b/packages/jwks-did-resolver/README.md
@@ -84,8 +84,10 @@ const jwksResult = await resolver.resolve("did:jwks:example.com")
 
 1. **Parse DID**: Extracts domain and path components
 2. **JWKS Discovery**:
-   - Direct: `https://domain{/path}/.well-known/jwks.json`
-   - OAuth2 Discovery: `https://domain{/path}/.well-known/openid-configuration`
+   - Root DID direct lookup: `https://domain/.well-known/jwks.json`
+   - Path DID direct lookup: `https://domain/{path}/jwks.json`
+   - Root DID OAuth2 discovery: `https://domain/.well-known/openid-configuration`
+   - Path DID OAuth2 discovery: `https://domain/.well-known/openid-configuration/{path}`
 3. **Transform**: Converts JWKS to DID verification methods
 4. **Return**: Standard DID Resolution result
 


### PR DESCRIPTION
## Summary
- update package READMEs to distinguish root DID and path DID JWKS discovery URLs
- align the path DID example with the current direct `{path}/jwks.json` behavior

Closes #13

## Verification
- pnpm exec oxfmt --check packages/did-jwks/README.md packages/jwks-did-resolver/README.md
- git diff --check
- rg -n "domain\{/path\}|/\.well-known/jwks\.json|/\.well-known/openid-configuration" packages/did-jwks/README.md packages/jwks-did-resolver/README.md README.md SPEC.md