### PR TITLE
fix: reject unsupported did representations

### DIFF
--- a/packages/jwks-did-resolver/src/resolver.test.ts
+++ b/packages/jwks-did-resolver/src/resolver.test.ts
@@ -133,6 +133,22 @@ describe("Resolver", () => {
     expectJwksDidDocument(did, doc.didDocument)
   })
 
+  it("returns representationNotSupported for unsupported accept values", async () => {
+    const mockFetch = vi.fn() as unknown as typeof globalThis.fetch
+
+    const did = "did:jwks:example.com"
+    const resolver = new Resolver(getResolver({ fetch: mockFetch }))
+    const doc = await resolver.resolve(did, {
+      accept: "application/did+cbor"
+    })
+
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(doc.didDocument).toBeNull()
+    expect(doc.didDocumentMetadata).toEqual({})
+    expect(doc.didResolutionMetadata.error).toBe("representationNotSupported")
+    expect(doc.didResolutionMetadata.message).toContain("application/did+cbor")
+  })
+
   it("returns error when fetch throws an exception", async () => {
     const mockFetch = vi
       .fn()

--- a/packages/jwks-did-resolver/src/resolver.test.ts
+++ b/packages/jwks-did-resolver/src/resolver.test.ts
@@ -149,6 +149,22 @@ describe("Resolver", () => {
     expect(doc.didResolutionMetadata.message).toContain("application/did+cbor")
   })
 
+  it("supports application wildcard accept values", async () => {
+    const mockFetch = mockFetchFn(exampleAuth0Jwks)
+
+    const did = "did:jwks:example.auth0.com"
+    const resolver = new Resolver(getResolver({ fetch: mockFetch }))
+    const doc = await resolver.resolve(did, {
+      accept: "application/*"
+    })
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expectJwksDidDocument(did, doc.didDocument)
+    expect(doc.didResolutionMetadata.contentType).toBe(
+      "application/did+ld+json"
+    )
+  })
+
   it("returns error when fetch throws an exception", async () => {
     const mockFetch = vi
       .fn()

--- a/packages/jwks-did-resolver/src/resolver.ts
+++ b/packages/jwks-did-resolver/src/resolver.ts
@@ -1,6 +1,14 @@
 import { isDidJwks, fetchJwksDidDocument } from "did-jwks"
 import type { FetchJwksOptions } from "did-jwks"
-import type { DIDResolutionResult, DIDResolver } from "did-resolver"
+import type {
+  DIDResolutionOptions,
+  DIDResolutionResult,
+  DIDResolver,
+  ParsedDID,
+  Resolvable
+} from "did-resolver"
+
+const DID_JWKS_CONTENT_TYPE = "application/did+ld+json"
 
 /**
  * Get a `did-resolver` compatible resolver for did:jwks
@@ -17,7 +25,12 @@ import type { DIDResolutionResult, DIDResolver } from "did-resolver"
 export function getResolver(opts: FetchJwksOptions = {}): {
   jwks: DIDResolver
 } {
-  async function resolve(did: string): Promise<DIDResolutionResult> {
+  async function resolve(
+    did: string,
+    _parsed: ParsedDID,
+    _resolver: Resolvable,
+    options: DIDResolutionOptions = {}
+  ): Promise<DIDResolutionResult> {
     if (!did) {
       return {
         didDocument: null,
@@ -31,6 +44,17 @@ export function getResolver(opts: FetchJwksOptions = {}): {
         didDocument: null,
         didDocumentMetadata: {},
         didResolutionMetadata: { error: "unsupportedDidMethod" }
+      }
+    }
+
+    if (!supportsAccept(options.accept)) {
+      return {
+        didDocument: null,
+        didDocumentMetadata: {},
+        didResolutionMetadata: {
+          error: "representationNotSupported",
+          message: `Unsupported DID representation: ${options.accept}`
+        }
       }
     }
 
@@ -60,11 +84,22 @@ export function getResolver(opts: FetchJwksOptions = {}): {
     return {
       didDocument,
       didDocumentMetadata: {},
-      didResolutionMetadata: { contentType: "application/did+ld+json" }
+      didResolutionMetadata: { contentType: DID_JWKS_CONTENT_TYPE }
     }
   }
 
   return {
     jwks: resolve
   }
+}
+
+function supportsAccept(accept?: string): boolean {
+  if (!accept) {
+    return true
+  }
+
+  return accept.split(",").some((value) => {
+    const [mediaType] = value.trim().split(";")
+    return mediaType === DID_JWKS_CONTENT_TYPE || mediaType === "*/*"
+  })
 }

--- a/packages/jwks-did-resolver/src/resolver.ts
+++ b/packages/jwks-did-resolver/src/resolver.ts
@@ -100,6 +100,10 @@ function supportsAccept(accept?: string): boolean {
 
   return accept.split(",").some((value) => {
     const [mediaType] = value.trim().split(";")
-    return mediaType === DID_JWKS_CONTENT_TYPE || mediaType === "*/*"
+    return (
+      mediaType === DID_JWKS_CONTENT_TYPE ||
+      mediaType === "application/*" ||
+      mediaType === "*/*"
+    )
   })
 }


### PR DESCRIPTION
## Summary
- handle unsupported DID resolution `accept` values before fetching JWKS
- return `representationNotSupported` for representations this resolver does not emit
- add resolver coverage that ensures unsupported accept values do not trigger network fetches

Closes #12

## Verification
- pnpm --filter=did-jwks build
- pnpm --filter=jwks-did-resolver exec vitest run src/resolver.test.ts
- pnpm run typecheck
- pnpm exec oxfmt --check packages/jwks-did-resolver/src/resolver.ts packages/jwks-did-resolver/src/resolver.test.ts
- git diff --check