### PR TITLE
fix: strip private JWK parameters from DID document keys

### DIFF
--- a/.changeset/strip-private-jwk-params.md
+++ b/.changeset/strip-private-jwk-params.md
@@ -1,0 +1,5 @@
+---
+"did-jwks": patch
+---
+
+Strip asymmetric private JWK parameters from DID document publicKeyJwk values

--- a/packages/did-jwks/src/did-jwks.create.test.ts
+++ b/packages/did-jwks/src/did-jwks.create.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest"
+import type { Did } from "web-identity-schemas"
+
+import { createDidJwksDidDocument } from "./did-jwks"
+
+describe("createDidJwksDidDocument()", () => {
+  it("strips asymmetric private JWK parameters from publicKeyJwk", async () => {
+    const did = "did:jwks:example.com" as Did<"jwks">
+    const privateRsaKey = {
+      kty: "RSA" as const,
+      use: "sig" as const,
+      kid: "key-1",
+      alg: "RS256" as const,
+      n: "test-n-value",
+      e: "AQAB",
+      d: "private-d",
+      p: "private-p",
+      q: "private-q",
+      dp: "private-dp",
+      dq: "private-dq",
+      qi: "private-qi"
+    }
+
+    const doc = await createDidJwksDidDocument(did, {
+      keys: [privateRsaKey]
+    })
+
+    expect(doc.verificationMethod).toHaveLength(1)
+    expect(doc.verificationMethod?.[0]).toMatchObject({
+      publicKeyJwk: {
+        kty: "RSA",
+        use: "sig",
+        kid: "key-1",
+        alg: "RS256",
+        n: "test-n-value",
+        e: "AQAB"
+      }
+    })
+
+    const serialized = JSON.stringify(doc.verificationMethod?.[0])
+    for (const secret of [
+      "private-d",
+      "private-p",
+      "private-q",
+      "private-dp",
+      "private-dq",
+      "private-qi"
+    ]) {
+      expect(serialized).not.toContain(secret)
+    }
+
+    // Input JWKS must not be mutated
+    expect(privateRsaKey.d).toBe("private-d")
+    expect(privateRsaKey.p).toBe("private-p")
+  })
+
+  it("strips EC private parameter d while preserving public members", async () => {
+    const did = "did:jwks:example.com" as Did<"jwks">
+    const privateEcKey = {
+      kty: "EC" as const,
+      use: "sig" as const,
+      crv: "P-256" as const,
+      x: "test-x",
+      y: "test-y",
+      d: "private-d"
+    }
+
+    const doc = await createDidJwksDidDocument(did, {
+      keys: [privateEcKey]
+    })
+
+    expect(doc.verificationMethod?.[0]).toMatchObject({
+      publicKeyJwk: {
+        kty: "EC",
+        use: "sig",
+        crv: "P-256",
+        x: "test-x",
+        y: "test-y"
+      }
+    })
+    expect(JSON.stringify(doc.verificationMethod?.[0])).not.toContain(
+      "private-d"
+    )
+    expect(privateEcKey.d).toBe("private-d")
+  })
+})

--- a/packages/did-jwks/src/did-jwks.ts
+++ b/packages/did-jwks/src/did-jwks.ts
@@ -8,6 +8,7 @@ import { DidDocumentSchema, UriSchema } from "web-identity-schemas/valibot"
 import { isDidWithMethod } from "web-identity-schemas/valibot"
 
 import { generateJwkThumbprint } from "./utils/jwk-thumbprint"
+import { toPublicJwk } from "./utils/to-public-jwk"
 export { isDid } from "web-identity-schemas/valibot"
 
 /**
@@ -45,7 +46,7 @@ export async function createDidJwksDidDocument(
       const thumbprint = await generateJwkThumbprint(key)
       return {
         use,
-        publicKeyJwk: key,
+        publicKeyJwk: toPublicJwk(key),
         thumbprint
       }
     })

--- a/packages/did-jwks/src/utils/to-public-jwk.ts
+++ b/packages/did-jwks/src/utils/to-public-jwk.ts
@@ -1,0 +1,29 @@
+import type { JsonWebKey } from "web-identity-schemas"
+
+/**
+ * Asymmetric JWK private parameters (RFC 7517 / RFC 7518).
+ * These must never appear in a DID document's publicKeyJwk.
+ */
+const JWK_PRIVATE_PARAMETERS = [
+  "d",
+  "p",
+  "q",
+  "dp",
+  "dq",
+  "qi",
+  "oth"
+] as const
+
+/**
+ * Return a shallow copy of a JWK with private key parameters removed.
+ * Public metadata (kid, use, alg, key_ops, x5c, …) is preserved.
+ */
+export function toPublicJwk(jwk: JsonWebKey): JsonWebKey {
+  const publicJwk = { ...jwk }
+
+  for (const parameter of JWK_PRIVATE_PARAMETERS) {
+    delete (publicJwk as Record<string, unknown>)[parameter]
+  }
+
+  return publicJwk
+}


### PR DESCRIPTION
## Summary

DID documents are public verification material. `createDidJwksDidDocument` previously copied each JWKS entry into `publicKeyJwk` as-is, so if a JWKS accidentally included asymmetric private parameters those secrets would be republished in the resolved DID document.

This change strips RFC 7517/7518 private fields before emission:

- `d`, `p`, `q`, `dp`, `dq`, `qi`, `oth`

Public metadata (`kid`, `use`, `alg`, `key_ops`, `x5c`, …) is preserved. The input JWKS object is not mutated.

Out of scope (tracked separately in #10): skipping/rejecting symmetric `oct` keys. This PR only removes asymmetric private parameters.

## Test plan
- [x] `pnpm --filter=did-jwks exec vitest run src/did-jwks.create.test.ts src/did-jwks.test.ts`
- [x] `pnpm run typecheck`