### PR TITLE
docs: document actual jwks-did-resolver error types

### DIFF
--- a/packages/jwks-did-resolver/README.md
+++ b/packages/jwks-did-resolver/README.md
@@ -93,20 +93,27 @@ const jwksResult = await resolver.resolve("did:jwks:example.com")
 
 ## Error Handling
 
-Returns standard DID Resolution error types:
+Returns DID Resolution error types used by this resolver (compatible with
+[`did-resolver`](https://github.com/decentralized-identity/did-resolver)):
 
 ```typescript
 const result = await resolver.resolve("did:jwks:invalid.domain")
 
 switch (result.didResolutionMetadata.error) {
   case "invalidDid":
-    // DID syntax error
+    // Empty or syntactically invalid DID
+    break
+  case "unsupportedDidMethod":
+    // DID method is not did:jwks
     break
   case "notFound":
-    // JWKS endpoint not found
+    // JWKS endpoint not found / could not be resolved
+    break
+  case "internalError":
+    // Unexpected failure while fetching or processing JWKS
     break
   case "representationNotSupported":
-    // Invalid accept header
+    // Reserved for unsupported accept / representation requests
     break
 }
 ```

--- a/packages/jwks-did-resolver/README.md
+++ b/packages/jwks-did-resolver/README.md
@@ -101,10 +101,10 @@ const result = await resolver.resolve("did:jwks:invalid.domain")
 
 switch (result.didResolutionMetadata.error) {
   case "invalidDid":
-    // Empty or syntactically invalid DID
+    // Empty DID string
     break
   case "unsupportedDidMethod":
-    // DID method is not did:jwks
+    // DID is not did:jwks (including non-jwks methods)
     break
   case "notFound":
     // JWKS endpoint not found / could not be resolved
@@ -113,7 +113,7 @@ switch (result.didResolutionMetadata.error) {
     // Unexpected failure while fetching or processing JWKS
     break
   case "representationNotSupported":
-    // Reserved for unsupported accept / representation requests
+    // Reserved; not currently returned by this resolver (see #12)
     break
 }
 ```


### PR DESCRIPTION
## Summary
- Document `unsupportedDidMethod` and `internalError`, which the resolver already returns
- Clarify comments to match `resolver.ts` behavior
- Leave `representationNotSupported` in the example (unused today; see #12)

## Test plan
- [x] Diff reviewed against `packages/jwks-did-resolver/src/resolver.ts`